### PR TITLE
Populate location on item update

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -10,3 +10,29 @@ npm run dev
 ```
 
 The server listens on `http://localhost:4000` by default and exposes basic routes for items and locations.
+
+## Testing Item Location Assignment
+
+You can manually verify that an item's location can be assigned or changed using the `PUT /items/:id` endpoint:
+
+1. **Create an item without a location**
+   ```bash
+   curl -X POST http://localhost:4000/items \
+        -H "Content-Type: application/json" \
+        -d '{"barcode":"123","metadata":{}}'
+   ```
+   Note the returned item `id`.
+
+2. **Assign a location**
+   ```bash
+   curl -X PUT http://localhost:4000/items/<id> \
+        -H "Content-Type: application/json" \
+        -d '{"location":"<locationId>"}'
+   ```
+
+3. **Fetch the updated item**
+   ```bash
+   curl http://localhost:4000/items/<id>
+   ```
+
+   The response should include the populated `location` object.

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -50,7 +50,7 @@ router.put("/:id", async (req, res, next) => {
   try {
     const item = await Item.findByIdAndUpdate(req.params.id, req.body, {
       new: true,
-    });
+    }).populate("location");
     if (!item) {
       return res.status(404).json({ message: "Item not found" });
     }


### PR DESCRIPTION
## Summary
- populate location when updating an item
- document how to manually verify assigning an item's location

## Testing
- `npm test` *(fails: Missing script)*