### PR TITLE
Initialize folders for Next.js app

### DIFF
--- a/codex-build-app/src/app/api/items/route.ts
+++ b/codex-build-app/src/app/api/items/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ message: "List items" });
+}

--- a/codex-build-app/src/app/api/locations/route.ts
+++ b/codex-build-app/src/app/api/locations/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ message: "List locations" });
+}

--- a/codex-build-app/src/app/check-in/page.tsx
+++ b/codex-build-app/src/app/check-in/page.tsx
@@ -1,0 +1,3 @@
+export default function CheckInPage() {
+  return <div>Check In Page</div>;
+}

--- a/codex-build-app/src/app/components/check-in/BarcodeScanner.tsx
+++ b/codex-build-app/src/app/components/check-in/BarcodeScanner.tsx
@@ -1,0 +1,3 @@
+export function BarcodeScanner() {
+  return <div>Barcode Scanner Placeholder</div>;
+}

--- a/codex-build-app/src/app/components/check-in/ScannedItemsList.tsx
+++ b/codex-build-app/src/app/components/check-in/ScannedItemsList.tsx
@@ -1,0 +1,3 @@
+export function ScannedItemsList() {
+  return <div>Scanned Items List</div>;
+}

--- a/codex-build-app/src/app/components/layout/MobileMenu.tsx
+++ b/codex-build-app/src/app/components/layout/MobileMenu.tsx
@@ -1,0 +1,3 @@
+export function MobileMenu() {
+  return <div>Mobile Menu</div>;
+}

--- a/codex-build-app/src/app/components/layout/Navbar.tsx
+++ b/codex-build-app/src/app/components/layout/Navbar.tsx
@@ -1,0 +1,3 @@
+export function Navbar() {
+  return <nav>Navbar</nav>;
+}

--- a/codex-build-app/src/app/components/storage/LocationCard.tsx
+++ b/codex-build-app/src/app/components/storage/LocationCard.tsx
@@ -1,0 +1,3 @@
+export function LocationCard() {
+  return <div>Location Card</div>;
+}

--- a/codex-build-app/src/app/components/storage/LocationForm.tsx
+++ b/codex-build-app/src/app/components/storage/LocationForm.tsx
@@ -1,0 +1,3 @@
+export function LocationForm() {
+  return <div>Location Form</div>;
+}

--- a/codex-build-app/src/app/components/storage/LocationsList.tsx
+++ b/codex-build-app/src/app/components/storage/LocationsList.tsx
@@ -1,0 +1,3 @@
+export function LocationsList() {
+  return <div>Locations List</div>;
+}

--- a/codex-build-app/src/app/components/ui/Button.tsx
+++ b/codex-build-app/src/app/components/ui/Button.tsx
@@ -1,0 +1,5 @@
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button(props: ButtonProps) {
+  return <button {...props} />;
+}

--- a/codex-build-app/src/app/components/ui/Input.tsx
+++ b/codex-build-app/src/app/components/ui/Input.tsx
@@ -1,0 +1,5 @@
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input(props: InputProps) {
+  return <input {...props} />;
+}

--- a/codex-build-app/src/app/hooks/useCamera.ts
+++ b/codex-build-app/src/app/hooks/useCamera.ts
@@ -1,0 +1,3 @@
+export function useCamera() {
+  // Placeholder hook
+}

--- a/codex-build-app/src/app/items/[barcode]/store/page.tsx
+++ b/codex-build-app/src/app/items/[barcode]/store/page.tsx
@@ -1,0 +1,7 @@
+interface PageProps {
+  params: { barcode: string };
+}
+
+export default function StoreItemPage({ params }: PageProps) {
+  return <div>Store item with barcode: {params.barcode}</div>;
+}

--- a/codex-build-app/src/app/lib/barcodeUtils.ts
+++ b/codex-build-app/src/app/lib/barcodeUtils.ts
@@ -1,0 +1,3 @@
+export function parseBarcode(value: string) {
+  return value.trim();
+}

--- a/codex-build-app/src/app/lib/storageService.ts
+++ b/codex-build-app/src/app/lib/storageService.ts
@@ -1,0 +1,3 @@
+export async function saveLocation() {
+  // Placeholder implementation
+}

--- a/codex-build-app/src/app/storage/new/page.tsx
+++ b/codex-build-app/src/app/storage/new/page.tsx
@@ -1,0 +1,3 @@
+export default function NewStoragePage() {
+  return <div>Add New Storage Location</div>;
+}

--- a/codex-build-app/src/app/storage/page.tsx
+++ b/codex-build-app/src/app/storage/page.tsx
@@ -1,0 +1,3 @@
+export default function StoragePage() {
+  return <div>Storage Locations</div>;
+}

--- a/codex-build-app/src/app/store/itemStore.ts
+++ b/codex-build-app/src/app/store/itemStore.ts
@@ -1,0 +1,3 @@
+export const itemStore = {
+  items: [],
+};

--- a/codex-build-app/src/app/store/locationStore.ts
+++ b/codex-build-app/src/app/store/locationStore.ts
@@ -1,0 +1,3 @@
+export const locationStore = {
+  locations: [],
+};

--- a/codex-build-app/src/app/types/index.ts
+++ b/codex-build-app/src/app/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./item";
+export * from "./location";

--- a/codex-build-app/src/app/types/item.ts
+++ b/codex-build-app/src/app/types/item.ts
@@ -1,0 +1,3 @@
+export interface Item {
+  barcode: string;
+}

--- a/codex-build-app/src/app/types/location.ts
+++ b/codex-build-app/src/app/types/location.ts
@@ -1,0 +1,4 @@
+export interface Location {
+  id: string;
+  name?: string;
+}


### PR DESCRIPTION
## Summary
- scaffold pages for check-in, storage, and item store flow
- add API route placeholders
- create component, lib, hooks, store and types directories with starter files

## Testing
- `npm run lint` *(fails: next not found)*