### PR TITLE
Implement React context stores for items and locations

### DIFF
--- a/codex-build-app/src/app/layout.tsx
+++ b/codex-build-app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { StoreProvider } from "./store/StoreProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <StoreProvider>{children}</StoreProvider>
       </body>
     </html>
   );

--- a/codex-build-app/src/app/store/StoreProvider.tsx
+++ b/codex-build-app/src/app/store/StoreProvider.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { ReactNode } from 'react';
+import { ItemStoreProvider } from './itemStore';
+import { LocationStoreProvider } from './locationStore';
+
+export function StoreProvider({ children }: { children: ReactNode }) {
+  return (
+    <ItemStoreProvider>
+      <LocationStoreProvider>{children}</LocationStoreProvider>
+    </ItemStoreProvider>
+  );
+}

--- a/codex-build-app/src/app/store/itemStore.ts
+++ b/codex-build-app/src/app/store/itemStore.ts
@@ -1,3 +1,45 @@
-export const itemStore = {
-  items: [],
-};
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import type { Item } from '../types';
+
+export interface ItemStore {
+  items: Item[];
+  setItems: (items: Item[]) => void;
+  addItem: (item: Item) => void;
+  updateItem: (item: Item) => void;
+  removeItem: (id: string) => void;
+}
+
+const ItemStoreContext = createContext<ItemStore | undefined>(undefined);
+
+export function ItemStoreProvider({ children }: { children: ReactNode }) {
+  const [items, setItemsState] = useState<Item[]>([]);
+
+  const setItems = (items: Item[]) => setItemsState(items);
+  const addItem = (item: Item) => setItemsState(prev => [...prev, item]);
+  const updateItem = (item: Item) =>
+    setItemsState(prev => prev.map(i => (i._id === item._id ? item : i)));
+  const removeItem = (id: string) =>
+    setItemsState(prev => prev.filter(i => i._id !== id));
+
+  const value: ItemStore = {
+    items,
+    setItems,
+    addItem,
+    updateItem,
+    removeItem,
+  };
+
+  return (
+    <ItemStoreContext.Provider value={value}>{children}</ItemStoreContext.Provider>
+  );
+}
+
+export function useItemStore(): ItemStore {
+  const context = useContext(ItemStoreContext);
+  if (!context) {
+    throw new Error('useItemStore must be used within ItemStoreProvider');
+  }
+  return context;
+}

--- a/codex-build-app/src/app/store/locationStore.ts
+++ b/codex-build-app/src/app/store/locationStore.ts
@@ -1,3 +1,50 @@
-export const locationStore = {
-  locations: [],
-};
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+import type { StorageLocation } from '../types';
+
+export interface LocationStore {
+  locations: StorageLocation[];
+  setLocations: (locations: StorageLocation[]) => void;
+  addLocation: (loc: StorageLocation) => void;
+  updateLocation: (loc: StorageLocation) => void;
+  removeLocation: (id: string) => void;
+}
+
+const LocationStoreContext = createContext<LocationStore | undefined>(undefined);
+
+export function LocationStoreProvider({ children }: { children: ReactNode }) {
+  const [locations, setLocationsState] = useState<StorageLocation[]>([]);
+
+  const setLocations = (l: StorageLocation[]) => setLocationsState(l);
+  const addLocation = (loc: StorageLocation) =>
+    setLocationsState(prev => [...prev, loc]);
+  const updateLocation = (loc: StorageLocation) =>
+    setLocationsState(prev =>
+      prev.map(l => (l._id === loc._id ? loc : l)),
+    );
+  const removeLocation = (id: string) =>
+    setLocationsState(prev => prev.filter(l => l._id !== id));
+
+  const value: LocationStore = {
+    locations,
+    setLocations,
+    addLocation,
+    updateLocation,
+    removeLocation,
+  };
+
+  return (
+    <LocationStoreContext.Provider value={value}>
+      {children}
+    </LocationStoreContext.Provider>
+  );
+}
+
+export function useLocationStore(): LocationStore {
+  const context = useContext(LocationStoreContext);
+  if (!context) {
+    throw new Error('useLocationStore must be used within LocationStoreProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a context-based `itemStore`
- add a context-based `locationStore`
- introduce `StoreProvider` to combine stores
- wrap app layout with the new provider

## Testing
- `npm run lint` *(fails: `next` not found)*