### PR TITLE
Implement reusable Button component

### DIFF
--- a/codex-build-app/src/app/components/ui/Button.module.css
+++ b/codex-build-app/src/app/components/ui/Button.module.css
@@ -1,0 +1,43 @@
+.button {
+  appearance: none;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font: inherit;
+  font-weight: 500;
+  transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.primary {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.secondary {
+  background: transparent;
+  color: var(--foreground);
+  border: 1px solid currentColor;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .primary:hover {
+    opacity: 0.9;
+  }
+
+  .secondary:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  @media (hover: hover) and (pointer: fine) {
+    .secondary:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+  }
+}

--- a/codex-build-app/src/app/components/ui/Button.tsx
+++ b/codex-build-app/src/app/components/ui/Button.tsx
@@ -1,5 +1,22 @@
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+import styles from "./Button.module.css";
 
-export function Button(props: ButtonProps) {
-  return <button {...props} />;
+export type ButtonVariant = "primary" | "secondary";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Visual style for the button */
+  variant?: ButtonVariant;
+  /** Additional class names to apply */
+  className?: string;
 }
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = "primary", className = "", ...props }, ref) => {
+    const classes = [styles.button, styles[variant], className]
+      .filter(Boolean)
+      .join(" ");
+
+    return <button ref={ref} className={classes} {...props} />;
+  }
+);
+
+Button.displayName = "Button";


### PR DESCRIPTION
## Summary
- add CSS module styling for buttons
- extend Button component with variants and forwarded ref

## Testing
- `npm run lint` *(fails: next not found)*