### PR TITLE
Add reusable Modal component

### DIFF
--- a/codex-build-app/src/app/components/ui/Modal.module.css
+++ b/codex-build-app/src/app/components/ui/Modal.module.css
@@ -1,0 +1,20 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  background: var(--background);
+  color: var(--foreground);
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}

--- a/codex-build-app/src/app/components/ui/Modal.tsx
+++ b/codex-build-app/src/app/components/ui/Modal.tsx
@@ -1,5 +1,57 @@
-interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {}
+"use client";
 
-export function Modal(props: ModalProps) {
-  return <div {...props}>Modal Placeholder</div>;
+import { useEffect } from "react";
+import ReactDOM from "react-dom";
+import styles from "./Modal.module.css";
+
+interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Controls whether the modal is visible */
+  isOpen: boolean;
+  /** Called when the user requests to close the modal */
+  onClose?: () => void;
+  /** Additional class names for the modal container */
+  className?: string;
+  /** Modal contents */
+  children: React.ReactNode;
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  children,
+  className = "",
+  ...props
+}: ModalProps) {
+  // Don't render anything if the modal isn't open
+  if (!isOpen) return null;
+
+  // Close when the Escape key is pressed
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose?.();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const modalClasses = [styles.modal, className].filter(Boolean).join(" ");
+
+  const content = (
+    <div className={styles.overlay} onClick={() => onClose?.()}>
+      <div
+        className={modalClasses}
+        onClick={e => e.stopPropagation()}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  );
+
+  // Use a portal so the modal renders outside regular DOM flow
+  return typeof window !== "undefined"
+    ? ReactDOM.createPortal(content, document.body)
+    : content;
 }


### PR DESCRIPTION
## Summary
- implement `Modal.tsx` as a client component with portal logic
- add CSS module for modal styles

## Testing
- `npm run lint` *(fails: `next` not found)*