### PR TITLE
Add navbar and mobile menu to root layout

### DIFF
--- a/codex-build-app/src/app/layout.tsx
+++ b/codex-build-app/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { StoreProvider } from "./store/StoreProvider";
+import { Navbar } from "./components/layout/Navbar";
+import { MobileMenu } from "./components/layout/MobileMenu";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +28,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <StoreProvider>{children}</StoreProvider>
+        <StoreProvider>
+          <header>
+            <Navbar />
+            <MobileMenu />
+          </header>
+          <main>{children}</main>
+        </StoreProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- update `layout.tsx` to include `Navbar` and `MobileMenu`
- define header/main structure and keep store provider

## Testing
- `npm run lint` *(fails: `next` not found)*