### PR TITLE
Implement base API helper

### DIFF
--- a/codex-build-app/src/app/lib/storageService.ts
+++ b/codex-build-app/src/app/lib/storageService.ts
@@ -1,3 +1,27 @@
-export async function saveLocation() {
-  // Placeholder implementation
+import type { StorageLocation } from '../types';
+
+const BASE_API_URL = 'http://localhost:5001/api';
+
+async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${BASE_API_URL}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Request failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function saveLocation(location: StorageLocation) {
+  return apiFetch<StorageLocation>('/locations', {
+    method: 'POST',
+    body: JSON.stringify(location),
+  });
 }


### PR DESCRIPTION
## Summary
- create a `BASE_API_URL` constant for API location
- add a generic `apiFetch` helper for fetch requests
- implement `saveLocation` using the helper

## Testing
- `npm run lint` *(fails: `next` not found)*