### PR TITLE
Add manual barcode entry form

### DIFF
--- a/codex-build-app/src/app/(pages)/check-in/page.tsx
+++ b/codex-build-app/src/app/(pages)/check-in/page.tsx
@@ -1,7 +1,14 @@
+import { ManualBarcodeEntry } from "../../components/check-in/ManualBarcodeEntry";
+
 export default function CheckInPage() {
+  const handleManualSubmit = (barcode: string) => {
+    console.log("Manual barcode submitted", barcode);
+  };
+
   return (
     <div>
       <h1>Check-In Page</h1>
+      <ManualBarcodeEntry onSubmit={handleManualSubmit} />
     </div>
   );
 }

--- a/codex-build-app/src/app/components/check-in/ManualBarcodeEntry.tsx
+++ b/codex-build-app/src/app/components/check-in/ManualBarcodeEntry.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { Input } from '../ui/Input';
+import { Button } from '../ui/Button';
+
+interface ManualBarcodeEntryProps {
+  onSubmit?: (barcode: string) => void;
+}
+
+export function ManualBarcodeEntry({ onSubmit }: ManualBarcodeEntryProps) {
+  const [barcode, setBarcode] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!barcode) return;
+    onSubmit?.(barcode);
+    setBarcode('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.5rem' }}>
+      <Input
+        value={barcode}
+        onChange={e => setBarcode(e.target.value)}
+        placeholder="Enter barcode"
+      />
+      <Button type="submit">Submit</Button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ManualBarcodeEntry` component for manual barcode input
- render the new form on the Check-In page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*