### PR TITLE
Implement item check-in handling

### DIFF
--- a/codex-build-app/src/app/(pages)/check-in/page.tsx
+++ b/codex-build-app/src/app/(pages)/check-in/page.tsx
@@ -1,14 +1,36 @@
+"use client";
+
+import { useState } from "react";
 import { ManualBarcodeEntry } from "../../components/check-in/ManualBarcodeEntry";
+import { BarcodeScanner } from "../../components/check-in/BarcodeScanner";
+import { addItem as addItemApi } from "../../lib/storageService";
+import { useItemStore } from "../../store/itemStore";
 
 export default function CheckInPage() {
-  const handleManualSubmit = (barcode: string) => {
-    console.log("Manual barcode submitted", barcode);
+  const { addItem } = useItemStore();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleBarcode = async (barcode: string, source: "scan" | "manual") => {
+    setError(null);
+    try {
+      const newItem = await addItemApi({
+        barcode,
+        scannedAt: new Date(),
+        source,
+      });
+      addItem(newItem);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message ?? "Failed to add item");
+    }
   };
 
   return (
     <div>
       <h1>Check-In Page</h1>
-      <ManualBarcodeEntry onSubmit={handleManualSubmit} />
+      {error && <p style={{ color: "red" }}>{error}</p>}
+      <BarcodeScanner onBarcodeScanned={(b) => handleBarcode(b, "scan")}/>
+      <ManualBarcodeEntry onSubmit={(b) => handleBarcode(b, "manual")}/>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement client-side logic for check-in page
- update page to add scanned item to global store using `storageService`

## Testing
- `npm run lint` *(fails: next not found)*