### PR TITLE
Include default name and quantity when adding items

### DIFF
--- a/codex-build-app/src/app/(pages)/check-in/page.tsx
+++ b/codex-build-app/src/app/(pages)/check-in/page.tsx
@@ -16,6 +16,10 @@ export default function CheckInPage() {
     try {
       const newItem = await addItemApi({
         barcode,
+        // TODO: Allow user to specify item name
+        name: `Item ${barcode}`,
+        // TODO: Allow user to specify quantity
+        quantity: 1,
         scannedAt: new Date(),
         source,
       });


### PR DESCRIPTION
## Summary
- ensure that items created during check-in have a name and quantity

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*