### PR TITLE
Add new storage location page

### DIFF
--- a/codex-build-app/src/app/(pages)/storage/new/page.tsx
+++ b/codex-build-app/src/app/(pages)/storage/new/page.tsx
@@ -1,7 +1,23 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LocationForm } from "../../../components/storage/LocationForm";
+import { useLocationStore } from "../../../store/locationStore";
+import type { StorageLocation } from "../../../types";
+
 export default function NewStoragePage() {
+  const router = useRouter();
+  const { addLocation } = useLocationStore();
+
+  const handleSubmitSuccess = (loc: StorageLocation) => {
+    addLocation(loc);
+    router.push("/storage");
+  };
+
   return (
-    <div>
-      <h1>New Storage Page</h1>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <h1>Add New Storage Location</h1>
+      <LocationForm onSubmitSuccess={handleSubmitSuccess} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement client-side page for adding storage locations
- navigate to `/storage` after creation and update the global store

## Testing
- `npm run lint` *(fails: `next` not found)*