### PR TITLE
Add item history page and update navigation

### DIFF
--- a/codex-build-app/src/app/(pages)/check-in/page.tsx
+++ b/codex-build-app/src/app/(pages)/check-in/page.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { ManualBarcodeEntry } from "../../components/check-in/ManualBarcodeEntry";
 import { BarcodeScanner } from "../../components/check-in/BarcodeScanner";
-import { ScannedItemsList } from "../../components/check-in/ScannedItemsList";
+import Link from "next/link";
+import { Button } from "../../components/ui/Button";
 import { addItem as addItemApi } from "../../lib/storageService";
 import { useItemStore } from "../../store/itemStore";
 
@@ -36,7 +37,11 @@ export default function CheckInPage() {
       {error && <p style={{ color: "red" }}>{error}</p>}
       <BarcodeScanner onBarcodeScanned={(b) => handleBarcode(b, "scan")}/>
       <ManualBarcodeEntry onSubmit={(b) => handleBarcode(b, "manual")}/>
-      <ScannedItemsList />
+      <Link href="/history" style={{ alignSelf: "flex-start" }}>
+        <Button type="button" variant="secondary">
+          View History
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/codex-build-app/src/app/(pages)/history/page.tsx
+++ b/codex-build-app/src/app/(pages)/history/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchItems } from "../../lib/storageService";
+import { useItemStore } from "../../store/itemStore";
+import { HistoryItemCard } from "../../components/history/HistoryItemCard";
+
+export default function HistoryPage() {
+  const { items, setItems } = useItemStore();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchItems()
+      .then((data) => {
+        if (!active) return;
+        setItems(data);
+        setLoading(false);
+      })
+      .catch((err: any) => {
+        console.error(err);
+        if (!active) return;
+        setError(err.message ?? "Failed to load items");
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [setItems]);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div style={{ color: "red" }}>{error}</div>;
+  if (items.length === 0) return <div>No items found.</div>;
+
+  const sorted = [...items].sort(
+    (a, b) => new Date(b.scannedAt).getTime() - new Date(a.scannedAt).getTime()
+  );
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <h1>Item History</h1>
+      {sorted.map((item) => (
+        <HistoryItemCard key={item._id} item={item} />
+      ))}
+    </div>
+  );
+}

--- a/codex-build-app/src/app/components/history/HistoryItemCard.tsx
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.tsx
@@ -1,0 +1,38 @@
+import type { Item } from "../../types";
+
+interface HistoryItemCardProps {
+  item: Item;
+}
+
+export function HistoryItemCard({ item }: HistoryItemCardProps) {
+  const {
+    barcode,
+    name,
+    quantity,
+    scannedAt,
+    location,
+  } = item;
+
+  const locationName =
+    typeof location === "object" && location ? location.name : undefined;
+
+  return (
+    <div style={{ border: "1px solid rgba(0,0,0,0.1)", padding: "0.75rem", borderRadius: 6 }}>
+      <h3 style={{ marginBottom: "0.5rem" }}>{name}</h3>
+      <div>
+        <strong>Barcode:</strong> {barcode}
+      </div>
+      <div>
+        <strong>Quantity:</strong> {quantity}
+      </div>
+      <div>
+        <strong>Scanned:</strong> {new Date(scannedAt).toLocaleString()}
+      </div>
+      {locationName && (
+        <div>
+          <strong>Location:</strong> {locationName}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/codex-build-app/src/app/components/layout/MobileMenu.tsx
+++ b/codex-build-app/src/app/components/layout/MobileMenu.tsx
@@ -30,6 +30,9 @@ export function MobileMenu() {
           <Link href="/check-in" onClick={() => setOpen(false)} role="menuitem">
             Check-In
           </Link>
+          <Link href="/history" onClick={() => setOpen(false)} role="menuitem">
+            History
+          </Link>
           <Link href="/storage" onClick={() => setOpen(false)} role="menuitem">
             Storage
           </Link>

--- a/codex-build-app/src/app/components/layout/Navbar.tsx
+++ b/codex-build-app/src/app/components/layout/Navbar.tsx
@@ -10,6 +10,9 @@ export function Navbar() {
       <Link href="/check-in" className={styles.link}>
         Check-in
       </Link>
+      <Link href="/history" className={styles.link}>
+        History
+      </Link>
       <Link href="/storage" className={styles.link}>
         Storage
       </Link>

--- a/codex-build-app/src/app/page.tsx
+++ b/codex-build-app/src/app/page.tsx
@@ -14,9 +14,12 @@ export default function Home() {
     >
       <h1>Warehouse Dashboard</h1>
       <p>Welcome! Use the links below to manage your inventory.</p>
-      <div style={{ display: "flex", gap: "1rem" }}>
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", justifyContent: "center" }}>
         <Link href="/check-in">
           <Button type="button">Check-in Items</Button>
+        </Link>
+        <Link href="/history">
+          <Button type="button" variant="secondary">Item History</Button>
         </Link>
         <Link href="/storage">
           <Button type="button" variant="secondary">


### PR DESCRIPTION
## Summary
- add Item History page to display all scanned items
- create `HistoryItemCard` component
- refactor Check-In page to remove inline list and link to History
- link Item History in Navbar and MobileMenu
- add history access from the home page

## Testing
- `npm run lint` *(fails: `next` not found)*