### PR TITLE
Render storage locations in responsive grid

### DIFF
--- a/codex-build-app/src/app/components/storage/LocationsList.module.css
+++ b/codex-build-app/src/app/components/storage/LocationsList.module.css
@@ -1,0 +1,23 @@
+.list {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 640px) {
+  .list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .list {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/codex-build-app/src/app/components/storage/LocationsList.tsx
+++ b/codex-build-app/src/app/components/storage/LocationsList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { LocationCard } from "./LocationCard";
 import { fetchLocations } from "../../lib/storageService";
 import { useLocationStore } from "../../store/locationStore";
+import styles from "./LocationsList.module.css";
 import type { StorageLocation } from "../../types";
 
 interface LocationsListProps {
@@ -16,7 +17,7 @@ interface LocationsListProps {
 }
 
 export function LocationsList({ onSelectLocation }: LocationsListProps) {
-  const { locations, setLocations } = useLocationStore();
+  const { locations: storageLocations, setLocations } = useLocationStore();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false); // Local flag to prevent refetching
@@ -59,13 +60,13 @@ export function LocationsList({ onSelectLocation }: LocationsListProps) {
     return <div style={{ color: "red" }}>{error}</div>;
   }
 
-  if (locations.length === 0) {
+  if (storageLocations.length === 0) {
     return <div>No locations available.</div>;
   }
 
   return (
-    <div style={{ display: "grid", gap: "1rem" }}>
-      {locations.map((loc) => (
+    <div className={styles.list}>
+      {storageLocations.map((loc) => (
         <div
           key={loc._id}
           role={onSelectLocation ? "button" : undefined}


### PR DESCRIPTION
## Summary
- display `LocationsList` items in a responsive grid layout
- support grid responsiveness with new CSS module

## Testing
- `npm run lint` *(fails: next not found)*