### PR TITLE
Improve item history layout

### DIFF
--- a/codex-build-app/src/app/(pages)/history/page.module.css
+++ b/codex-build-app/src/app/(pages)/history/page.module.css
@@ -1,0 +1,26 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  max-width: 1024px;
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/codex-build-app/src/app/(pages)/history/page.tsx
+++ b/codex-build-app/src/app/(pages)/history/page.tsx
@@ -4,6 +4,11 @@ import { useEffect, useState } from "react";
 import { fetchItems } from "../../lib/storageService";
 import { useItemStore } from "../../store/itemStore";
 import { HistoryItemCard } from "../../components/history/HistoryItemCard";
+import styles from "./page.module.css";
+
+/**
+ * Displays the history of scanned items in a responsive grid of cards.
+ */
 
 export default function HistoryPage() {
   const { items, setItems } = useItemStore();
@@ -44,11 +49,13 @@ export default function HistoryPage() {
   );
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+    <div className={styles.page}>
       <h1>Item History</h1>
-      {sorted.map((item) => (
-        <HistoryItemCard key={item._id} item={item} />
-      ))}
+      <div className={styles.grid}>
+        {sorted.map((item) => (
+          <HistoryItemCard key={item._id} item={item} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/codex-build-app/src/app/components/history/HistoryItemCard.module.css
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.module.css
@@ -1,0 +1,39 @@
+.card {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: box-shadow 0.2s;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .card:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  }
+}
+
+.name {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.label {
+  font-weight: 500;
+  margin-right: 0.25rem;
+}
+
+.meta {
+  font-size: 0.875rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .card {
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/codex-build-app/src/app/components/history/HistoryItemCard.tsx
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.tsx
@@ -1,36 +1,35 @@
 import type { Item } from "../../types";
+import styles from "./HistoryItemCard.module.css";
+
+/**
+ * Displays a single item from the history list in a card format.
+ */
 
 interface HistoryItemCardProps {
   item: Item;
 }
 
 export function HistoryItemCard({ item }: HistoryItemCardProps) {
-  const {
-    barcode,
-    name,
-    quantity,
-    scannedAt,
-    location,
-  } = item;
-
+  const { barcode, name, quantity, scannedAt, location } = item;
   const locationName =
     typeof location === "object" && location ? location.name : undefined;
 
   return (
-    <div style={{ border: "1px solid rgba(0,0,0,0.1)", padding: "0.75rem", borderRadius: 6 }}>
-      <h3 style={{ marginBottom: "0.5rem" }}>{name}</h3>
-      <div>
-        <strong>Barcode:</strong> {barcode}
+    <div className={styles.card}>
+      <h3 className={styles.name}>{name}</h3>
+      <div className={styles.meta}>
+        <span className={styles.label}>Barcode:</span> {barcode}
       </div>
-      <div>
-        <strong>Quantity:</strong> {quantity}
+      <div className={styles.meta}>
+        <span className={styles.label}>Quantity:</span> {quantity}
       </div>
-      <div>
-        <strong>Scanned:</strong> {new Date(scannedAt).toLocaleString()}
+      <div className={styles.meta}>
+        <span className={styles.label}>Scanned:</span>{" "}
+        {new Date(scannedAt).toLocaleString()}
       </div>
       {locationName && (
-        <div>
-          <strong>Location:</strong> {locationName}
+        <div className={styles.meta}>
+          <span className={styles.label}>Location:</span> {locationName}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- implement responsive card component for history items
- add modern grid layout for item history page

## Testing
- `npm --prefix codex-build-app run lint` *(fails: next not found)*
- `npm --prefix codex-build-app run build` *(fails: next not found)*