### PR TITLE
Implement light color scheme

### DIFF
--- a/codex-build-app/src/app/components/check-in/BarcodeScanner.module.css
+++ b/codex-build-app/src/app/components/check-in/BarcodeScanner.module.css
@@ -3,7 +3,7 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   overflow: hidden;
-  background: var(--background);
+  background: var(--surface);
 }
 
 .webcam {

--- a/codex-build-app/src/app/components/history/HistoryItemCard.module.css
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.module.css
@@ -2,7 +2,7 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   padding: 1rem;
-  background: var(--background);
+  background: var(--surface);
   color: var(--foreground);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   display: flex;

--- a/codex-build-app/src/app/components/storage/LocationCard.module.css
+++ b/codex-build-app/src/app/components/storage/LocationCard.module.css
@@ -2,7 +2,7 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   padding: 1rem;
-  background: var(--background);
+  background: var(--surface);
   color: var(--foreground);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   overflow: hidden;

--- a/codex-build-app/src/app/components/ui/Input.module.css
+++ b/codex-build-app/src/app/components/ui/Input.module.css
@@ -2,7 +2,7 @@
   appearance: none;
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border: 1px solid rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 6px;
   font: inherit;
   color: inherit;

--- a/codex-build-app/src/app/globals.css
+++ b/codex-build-app/src/app/globals.css
@@ -1,12 +1,14 @@
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #212121;
+  --surface: #f5f5f5;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --surface: #171717;
   }
 }
 
@@ -24,6 +26,15 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--background);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
 * {
   box-sizing: border-box;
   padding: 0;
@@ -38,5 +49,10 @@ a {
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;
+  }
+
+  header {
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   }
 }


### PR DESCRIPTION
## Summary
- add surface background variable and switch to light theme colors
- style header with sticky positioning and shadow
- adjust card and scanner backgrounds for contrast
- refine input borders for light theme

## Testing
- `npm run lint` *(fails: next not found)*