### PR TITLE
Improve edit item form UI contrast

### DIFF
--- a/codex-build-app/src/app/(pages)/history/page.module.css
+++ b/codex-build-app/src/app/(pages)/history/page.module.css
@@ -13,6 +13,18 @@
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
+.modalContent {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modalTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
 @media (min-width: 640px) {
   .grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/codex-build-app/src/app/(pages)/history/page.tsx
+++ b/codex-build-app/src/app/(pages)/history/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { fetchItems, deleteItem as deleteItemApi } from "../../lib/storageService";
+import {
+  fetchItems,
+  deleteItem as deleteItemApi,
+} from "../../lib/storageService";
 import type { Item } from "../../types";
 import { useItemStore } from "../../store/itemStore";
 import { HistoryItemCard } from "../../components/history/HistoryItemCard";
@@ -70,7 +73,7 @@ export default function HistoryPage() {
   if (items.length === 0) return <div>No items found.</div>;
 
   const sorted = [...items].sort(
-    (a, b) => new Date(b.scannedAt).getTime() - new Date(a.scannedAt).getTime()
+    (a, b) => new Date(b.scannedAt).getTime() - new Date(a.scannedAt).getTime(),
   );
   const filtered = sorted.filter((it) => {
     const term = search.toLowerCase();
@@ -104,8 +107,8 @@ export default function HistoryPage() {
 
       <Modal isOpen={Boolean(editItem)} onClose={() => setEditItem(null)}>
         {editItem && (
-          <div style={{ padding: "1rem" }}>
-            <h2>Edit Item</h2>
+          <div className={styles.modalContent}>
+            <h2 className={styles.modalTitle}>Edit Item</h2>
             <ItemForm item={editItem} onSubmitSuccess={handleEditSuccess} />
           </div>
         )}

--- a/codex-build-app/src/app/components/items/ItemForm.tsx
+++ b/codex-build-app/src/app/components/items/ItemForm.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useState, FormEvent } from "react";
+import { useState, FormEvent } from "react";
 import { Input } from "../ui/Input";
 import { Button } from "../ui/Button";
-import { updateItem, fetchLocations } from "../../lib/storageService";
+import { updateItem } from "../../lib/storageService";
 import { useItemStore } from "../../store/itemStore";
-import { useLocationStore } from "../../store/locationStore";
-import type { Item, StorageLocation } from "../../types";
+import type { Item } from "../../types";
 
 interface ItemFormProps {
   item: Item;
@@ -17,45 +16,20 @@ export function ItemForm({ item, onSubmitSuccess }: ItemFormProps) {
   const [barcode, setBarcode] = useState(item.barcode);
   const [name, setName] = useState(item.name);
   const [quantity, setQuantity] = useState(item.quantity);
-  const [metadata, setMetadata] = useState(
-    item.metadata ? JSON.stringify(item.metadata, null, 2) : ""
-  );
-  const [locationId, setLocationId] = useState(
-    typeof item.location === "object" && item.location
-      ? item.location._id
-      : typeof item.location === "string"
-      ? item.location
-      : ""
-  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { updateItem: updateItemInStore } = useItemStore();
-  const { locations, setLocations } = useLocationStore();
-
-  useEffect(() => {
-    if (locations.length === 0) {
-      fetchLocations()
-        .then((locs) => setLocations(locs))
-        .catch((err) => console.error(err));
-    }
-  }, [locations.length, setLocations]);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
     setLoading(true);
     try {
-      let meta: Item["metadata"] | undefined;
-      if (metadata.trim()) {
-        meta = JSON.parse(metadata);
-      }
       const updated = await updateItem(item._id, {
         barcode,
         name,
         quantity,
-        metadata: meta,
-        location: locationId || null,
       });
       updateItemInStore(updated);
       onSubmitSuccess?.(updated);
@@ -82,7 +56,11 @@ export function ItemForm({ item, onSubmitSuccess }: ItemFormProps) {
       </label>
       <label>
         Name
-        <Input value={name} onChange={(e) => setName(e.target.value)} required />
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
       </label>
       <label>
         Quantity
@@ -92,38 +70,6 @@ export function ItemForm({ item, onSubmitSuccess }: ItemFormProps) {
           onChange={(e) => setQuantity(Number(e.target.value))}
           required
         />
-      </label>
-      <label>
-        Metadata
-        <textarea
-          value={metadata}
-          onChange={(e) => setMetadata(e.target.value)}
-          rows={3}
-          style={{
-            padding: "0.5rem",
-            border: "1px solid rgba(0,0,0,0.2)",
-            borderRadius: "6px",
-          }}
-        />
-      </label>
-      <label>
-        Location
-        <select
-          value={locationId}
-          onChange={(e) => setLocationId(e.target.value)}
-          style={{
-            padding: "0.5rem",
-            border: "1px solid rgba(0,0,0,0.2)",
-            borderRadius: "6px",
-          }}
-        >
-          <option value="">Unassigned</option>
-          {locations.map((loc) => (
-            <option key={loc._id} value={loc._id}>
-              {loc.name}
-            </option>
-          ))}
-        </select>
       </label>
       {error && <p style={{ color: "red" }}>{error}</p>}
       <Button type="submit" disabled={loading}>

--- a/codex-build-app/src/app/components/ui/Input.module.css
+++ b/codex-build-app/src/app/components/ui/Input.module.css
@@ -2,12 +2,14 @@
   appearance: none;
   width: 100%;
   padding: 0.5rem 0.75rem;
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: 1px solid #cccccc;
   border-radius: 6px;
   font: inherit;
   color: inherit;
-  background: var(--background);
-  transition: border-color 0.2s;
+  background: #ffffff;
+  transition:
+    border-color 0.2s,
+    background 0.2s;
 }
 
 .input:focus {
@@ -17,6 +19,7 @@
 
 @media (prefers-color-scheme: dark) {
   .input {
-    border-color: rgba(255, 255, 255, 0.3);
+    background: #1e1e1e;
+    border-color: #555555;
   }
 }

--- a/codex-build-app/src/app/components/ui/Modal.module.css
+++ b/codex-build-app/src/app/components/ui/Modal.module.css
@@ -19,6 +19,8 @@
   overflow-y: auto;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
   animation: scaleIn 0.2s ease-out;
+  border-color: #fff3;
+  border: 1px solid;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- lighten input backgrounds and borders for contrast
- remove metadata and location fields from edit item form
- style edit modal and title for clarity

## Testing
- `npm run lint` *(fails: `next` not found)*