### PR TITLE
Add item check-in modal

### DIFF
--- a/codex-build-app/src/app/(pages)/history/page.tsx
+++ b/codex-build-app/src/app/(pages)/history/page.tsx
@@ -8,9 +8,8 @@ import {
 import type { Item } from "../../types";
 import { useItemStore } from "../../store/itemStore";
 import { HistoryItemCard } from "../../components/history/HistoryItemCard";
-import { Modal } from "../../components/ui/Modal";
+import { CheckInItemModal } from "../../components/history/CheckInItemModal";
 import { Input } from "../../components/ui/Input";
-import { ItemForm } from "../../components/items/ItemForm";
 import styles from "./page.module.css";
 
 /**
@@ -18,11 +17,11 @@ import styles from "./page.module.css";
  */
 
 export default function HistoryPage() {
-  const { items, setItems, updateItem, removeItem } = useItemStore();
+  const { items, setItems, removeItem } = useItemStore();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [editItem, setEditItem] = useState<Item | null>(null);
+  const [checkInItem, setCheckInItem] = useState<Item | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -49,12 +48,8 @@ export default function HistoryPage() {
     };
   }, [setItems]);
 
-  const handleEdit = (item: Item) => {
-    setEditItem(item);
-  };
-
-  const handleEditSuccess = () => {
-    setEditItem(null);
+  const handleCheckIn = (item: Item) => {
+    setCheckInItem(item);
   };
 
   const handleDelete = async (item: Item) => {
@@ -99,20 +94,17 @@ export default function HistoryPage() {
           <HistoryItemCard
             key={item._id}
             item={item}
-            onEdit={handleEdit}
+            onCheckIn={handleCheckIn}
             onDelete={handleDelete}
           />
         ))}
       </div>
 
-      <Modal isOpen={Boolean(editItem)} onClose={() => setEditItem(null)}>
-        {editItem && (
-          <div className={styles.modalContent}>
-            <h2 className={styles.modalTitle}>Edit Item</h2>
-            <ItemForm item={editItem} onSubmitSuccess={handleEditSuccess} />
-          </div>
-        )}
-      </Modal>
+      <CheckInItemModal
+        isOpen={Boolean(checkInItem)}
+        item={checkInItem!}
+        onClose={() => setCheckInItem(null)}
+      />
     </div>
   );
 }

--- a/codex-build-app/src/app/components/history/CheckInItemModal.module.css
+++ b/codex-build-app/src/app/components/history/CheckInItemModal.module.css
@@ -1,0 +1,40 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.closeButton {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 4px;
+}
+
+.closeButton:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.listWrapper {
+  margin-top: 0.75rem;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.nestedContent {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}

--- a/codex-build-app/src/app/components/history/CheckInItemModal.tsx
+++ b/codex-build-app/src/app/components/history/CheckInItemModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Modal } from "../ui/Modal";
+import { Button } from "../ui/Button";
+import { LocationsList } from "../storage/LocationsList";
+import { LocationForm } from "../storage/LocationForm";
+import { updateItem } from "../../lib/storageService";
+import { useItemStore } from "../../store/itemStore";
+import type { Item, StorageLocation } from "../../types";
+import styles from "./CheckInItemModal.module.css";
+
+interface CheckInItemModalProps {
+  item: Item;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function CheckInItemModal({ item, isOpen, onClose }: CheckInItemModalProps) {
+  const { updateItem: updateItemInStore } = useItemStore();
+  const [showNewStorage, setShowNewStorage] = useState(false);
+
+  const handleSelect = async (loc: StorageLocation) => {
+    try {
+      const updated = await updateItem(item._id, { location: loc._id });
+      updateItemInStore(updated);
+      onClose();
+    } catch (err: any) {
+      console.error(err);
+      alert(err.message ?? "Failed to check in item");
+    }
+  };
+
+  const handleNewLocation = (loc: StorageLocation) => {
+    setShowNewStorage(false);
+    handleSelect(loc);
+  };
+
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose} className={styles.modal}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>Check In Item</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            className={styles.closeButton}
+            onClick={onClose}
+          >
+            ✖
+          </button>
+        </div>
+        <Button type="button" onClick={() => setShowNewStorage(true)}>
+          Create New Storage
+        </Button>
+        <div className={styles.listWrapper}>
+          <LocationsList onSelectLocation={handleSelect} />
+        </div>
+      </Modal>
+
+      <Modal isOpen={showNewStorage} onClose={() => setShowNewStorage(false)}>
+        <div className={styles.nestedContent}>
+          <h3>Add New Storage Location</h3>
+          <LocationForm onSubmitSuccess={handleNewLocation} />
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/codex-build-app/src/app/components/history/HistoryItemCard.tsx
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.tsx
@@ -7,15 +7,11 @@ import styles from "./HistoryItemCard.module.css";
 
 interface HistoryItemCardProps {
   item: Item;
-  onEdit?: (item: Item) => void;
+  onCheckIn?: (item: Item) => void;
   onDelete?: (item: Item) => void;
 }
 
-export function HistoryItemCard({
-  item,
-  onEdit,
-  onDelete,
-}: HistoryItemCardProps) {
+export function HistoryItemCard({ item, onCheckIn, onDelete }: HistoryItemCardProps) {
   const { barcode, name, quantity, scannedAt, location } = item;
   const locationName =
     typeof location === "object" && location ? location.name : undefined;
@@ -38,16 +34,16 @@ export function HistoryItemCard({
           <span className={styles.label}>Location:</span> {locationName}
         </div>
       )}
-      {(onEdit || onDelete) && (
+      {(onCheckIn || onDelete) && (
         <div className={styles.actions}>
-          {onEdit && (
+          {onCheckIn && (
             <button
               type="button"
               className={styles.iconButton}
-              aria-label="Edit item"
-              onClick={() => onEdit(item)}
+              aria-label="Check in item"
+              onClick={() => onCheckIn(item)}
             >
-              🖋️
+              📥
             </button>
           )}
           {onDelete && (


### PR DESCRIPTION
## Summary
- replace edit function on history cards with check-in action
- add `CheckInItemModal` component
- wire up modal in the item history page

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next')*
- `npm run lint` *(fails: next: not found)*