### PR TITLE
Add delete confirmation modal

### DIFF
--- a/codex-build-app/src/app/(pages)/history/page.tsx
+++ b/codex-build-app/src/app/(pages)/history/page.tsx
@@ -9,6 +9,7 @@ import type { Item } from "../../types";
 import { useItemStore } from "../../store/itemStore";
 import { HistoryItemCard } from "../../components/history/HistoryItemCard";
 import { CheckInItemModal } from "../../components/history/CheckInItemModal";
+import { DeleteConfirmModal } from "../../components/history/DeleteConfirmModal";
 import { Input } from "../../components/ui/Input";
 import { ToggleSwitch } from "../../components/ui/ToggleSwitch";
 import styles from "./page.module.css";
@@ -24,6 +25,8 @@ export default function HistoryPage() {
   const [search, setSearch] = useState("");
   const [showStored, setShowStored] = useState(false);
   const [checkInItem, setCheckInItem] = useState<Item | null>(null);
+  const [deleteItem, setDeleteItem] = useState<Item | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -54,14 +57,21 @@ export default function HistoryPage() {
     setCheckInItem(item);
   };
 
-  const handleDelete = async (item: Item) => {
-    if (!confirm("Delete this entry?")) return;
+  const handleDelete = (item: Item) => {
+    setDeleteItem(item);
+  };
+
+  const confirmDelete = async (item: Item) => {
+    setDeleting(true);
     try {
       await deleteItemApi(item._id);
       removeItem(item._id);
+      setDeleteItem(null);
     } catch (err: any) {
       console.error(err);
       alert(err.message ?? "Failed to delete item");
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -123,6 +133,13 @@ export default function HistoryPage() {
         isOpen={Boolean(checkInItem)}
         item={checkInItem!}
         onClose={() => setCheckInItem(null)}
+      />
+      <DeleteConfirmModal
+        isOpen={Boolean(deleteItem)}
+        item={deleteItem}
+        onCancel={() => setDeleteItem(null)}
+        onConfirm={confirmDelete}
+        deleting={deleting}
       />
     </div>
   );

--- a/codex-build-app/src/app/components/history/DeleteConfirmModal.module.css
+++ b/codex-build-app/src/app/components/history/DeleteConfirmModal.module.css
@@ -1,0 +1,25 @@
+.modal {
+  max-width: 420px;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.message {
+  font-size: 0.95rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}

--- a/codex-build-app/src/app/components/history/DeleteConfirmModal.tsx
+++ b/codex-build-app/src/app/components/history/DeleteConfirmModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Modal } from "../ui/Modal";
+import { Button } from "../ui/Button";
+import type { Item } from "../../types";
+import styles from "./DeleteConfirmModal.module.css";
+
+interface DeleteConfirmModalProps {
+  item: Item | null;
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: (item: Item) => void;
+  deleting?: boolean;
+}
+
+export function DeleteConfirmModal({
+  item,
+  isOpen,
+  onCancel,
+  onConfirm,
+  deleting = false,
+}: DeleteConfirmModalProps) {
+  if (!item) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} className={styles.modal}>
+      <div className={styles.content}>
+        <h2 className={styles.title}>Confirm Deletion</h2>
+        <p className={styles.message}>
+          Are you sure you want to delete this item? This action cannot be undone.
+        </p>
+        <div className={styles.actions}>
+          <Button type="button" variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="danger"
+            onClick={() => onConfirm(item)}
+            disabled={deleting}
+          >
+            Delete
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/codex-build-app/src/app/components/ui/Button.module.css
+++ b/codex-build-app/src/app/components/ui/Button.module.css
@@ -24,6 +24,11 @@
   border: 1px solid currentColor;
 }
 
+.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .primary:hover {
     opacity: 0.9;
@@ -32,12 +37,19 @@
   .secondary:hover {
     background: rgba(0, 0, 0, 0.05);
   }
+
+  .danger:hover {
+    opacity: 0.9;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
   @media (hover: hover) and (pointer: fine) {
     .secondary:hover {
       background: rgba(255, 255, 255, 0.1);
+    }
+    .danger:hover {
+      opacity: 0.9;
     }
   }
 }

--- a/codex-build-app/src/app/components/ui/Button.tsx
+++ b/codex-build-app/src/app/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./Button.module.css";
 
-export type ButtonVariant = "primary" | "secondary";
+export type ButtonVariant = "primary" | "secondary" | "danger";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual style for the button */

--- a/codex-build-app/src/app/globals.css
+++ b/codex-build-app/src/app/globals.css
@@ -2,6 +2,7 @@
   --background: #ffffff;
   --foreground: #212121;
   --surface: #f5f5f5;
+  --danger: #e02424;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -9,6 +10,7 @@
     --background: #0a0a0a;
     --foreground: #ededed;
     --surface: #171717;
+    --danger: #ff4d4d;
   }
 }
 


### PR DESCRIPTION
## Summary
- add DeleteConfirmModal component for history page
- support `danger` button variant for red confirm buttons
- expose `--danger` color in CSS variables
- update Item History page to use the confirmation modal

## Testing
- `npm run lint` *(fails: `next: not found`)*