### PR TITLE
Add quantity confirmation modal for barcode scans and entries

### DIFF
--- a/backend/src/models/item.js
+++ b/backend/src/models/item.js
@@ -1,10 +1,21 @@
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
 
 const itemSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    default: function () {
+      return this.barcode ? `Item ${this.barcode}` : "Unnamed Item";
+    },
+  },
+  quantity: { type: Number, default: 1 },
   barcode: { type: String, required: true },
   scannedAt: { type: Date, default: Date.now },
   metadata: { type: mongoose.Schema.Types.Mixed },
-  location: { type: mongoose.Schema.Types.ObjectId, ref: 'Location', default: null }
+  location: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Location",
+    default: null,
+  },
 });
 
-export default mongoose.model('Item', itemSchema);
+export default mongoose.model("Item", itemSchema);

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -62,6 +62,11 @@ router.post(
   "/",
   validate([
     body("barcode").isString().notEmpty().withMessage("barcode is required"),
+    body("name").optional().isString().withMessage("name must be a string"),
+    body("quantity")
+      .optional()
+      .isNumeric()
+      .withMessage("quantity must be a number"),
     body("metadata")
       .optional()
       .isObject()
@@ -73,8 +78,17 @@ router.post(
   ]),
   async (req, res, next) => {
     try {
-      const { barcode, metadata, locationId } = req.body;
+      const { barcode, name, quantity, metadata, locationId } = req.body;
       const data = { barcode, metadata };
+
+      if (name !== undefined) {
+        data.name = name;
+      }
+
+      if (quantity !== undefined) {
+        data.quantity = quantity;
+      }
+
       if (locationId) {
         data.location = locationId;
       }
@@ -96,6 +110,11 @@ router.put(
       .isString()
       .notEmpty()
       .withMessage("barcode must be string"),
+    body("name").optional().isString().withMessage("name must be a string"),
+    body("quantity")
+      .optional()
+      .isNumeric()
+      .withMessage("quantity must be a number"),
     body("metadata")
       .optional()
       .isObject()

--- a/codex-build-app/src/app/(pages)/check-in/page.tsx
+++ b/codex-build-app/src/app/(pages)/check-in/page.tsx
@@ -13,15 +13,18 @@ export default function CheckInPage() {
   const { addItem } = useItemStore();
   const [error, setError] = useState<string | null>(null);
 
-  const handleBarcode = async (barcode: string, source: "scan" | "manual") => {
+  const handleBarcode = async (
+    barcode: string,
+    quantity: number,
+    source: "scan" | "manual"
+  ) => {
     setError(null);
     try {
       const defaultName = `Item ${barcode}`;
-      const defaultQuantity = 1;
       const newItem = await addItemApi({
         barcode,
         name: defaultName,
-        quantity: defaultQuantity,
+        quantity,
         scannedAt: new Date(),
         source,
       });
@@ -38,10 +41,10 @@ export default function CheckInPage() {
       {error && <p className={styles.error}>{error}</p>}
       <div className={styles.content}>
         <div className={styles.scanner}>
-          <BarcodeScanner onBarcodeScanned={(b) => handleBarcode(b, "scan")}/>
+          <BarcodeScanner onBarcodeScanned={(b, q) => handleBarcode(b, q, "scan")}/>
         </div>
         <div className={styles.controls}>
-          <ManualBarcodeEntry onSubmit={(b) => handleBarcode(b, "manual")}/>
+          <ManualBarcodeEntry onSubmit={(b, q) => handleBarcode(b, q, "manual")}/>
           <Link href="/history">
             <Button type="button" variant="secondary">View History</Button>
           </Link>

--- a/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
+++ b/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
@@ -1,0 +1,76 @@
+.modal {
+  max-width: 90vw;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+.barcodeInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon {
+  font-size: 2rem;
+  color: green;
+}
+
+.quantityRow {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.qtyInput {
+  width: 3rem;
+  text-align: center;
+  font-size: 1rem;
+  padding: 0.25rem;
+  background: var(--surface);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: inherit;
+}
+
+.qtyButton {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  background: var(--surface);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.qtyButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .qtyInput {
+    background: #1e1e1e;
+    border-color: #555;
+  }
+
+  .qtyButton {
+    background: #1e1e1e;
+    border-color: #555;
+  }
+}

--- a/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
+++ b/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
@@ -30,6 +30,7 @@
 
 .qtyInput {
   width: 3rem;
+  max-width: 4rem;
   text-align: center;
   font-size: 1rem;
   padding: 0.25rem;

--- a/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.tsx
+++ b/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal } from "../ui/Modal";
+import { Button } from "../ui/Button";
+import styles from "./BarcodeConfirmModal.module.css";
+
+interface BarcodeConfirmModalProps {
+  barcode: string;
+  isOpen: boolean;
+  onConfirm: (quantity: number) => void;
+  onTryAgain?: () => void;
+  onClose?: () => void;
+}
+
+export function BarcodeConfirmModal({
+  barcode,
+  isOpen,
+  onConfirm,
+  onTryAgain,
+  onClose,
+}: BarcodeConfirmModalProps) {
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (isOpen) setQuantity(1);
+  }, [isOpen]);
+
+  const decrease = () => setQuantity((q) => Math.max(1, q - 1));
+  const increase = () => setQuantity((q) => q + 1);
+
+  const handleConfirm = () => {
+    onConfirm(quantity);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className={styles.modal}>
+      <div
+        className={styles.content}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleConfirm();
+          }
+        }}
+      >
+        <div className={styles.barcodeInfo}>
+          <span className={styles.icon}>✔</span>
+          <p className={styles.message}>
+            Detected barcode:
+            <br />
+            <strong>{barcode}</strong>
+          </p>
+        </div>
+        <div className={styles.quantityRow}>
+          <button
+            type="button"
+            onClick={decrease}
+            disabled={quantity <= 1}
+            aria-label="Decrease quantity"
+            className={styles.qtyButton}
+          >
+            -
+          </button>
+          <input
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) =>
+              setQuantity(Math.max(1, Number(e.target.value)))
+            }
+            className={styles.qtyInput}
+          />
+          <button
+            type="button"
+            onClick={increase}
+            aria-label="Increase quantity"
+            className={styles.qtyButton}
+          >
+            +
+          </button>
+        </div>
+        <div className={styles.actions}>
+          <Button onClick={handleConfirm} autoFocus>
+            Confirm
+          </Button>
+          {onTryAgain && (
+            <Button variant="secondary" onClick={onTryAgain}>
+              Try Again
+            </Button>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/codex-build-app/src/app/components/check-in/BarcodeScanner.tsx
+++ b/codex-build-app/src/app/components/check-in/BarcodeScanner.tsx
@@ -2,14 +2,13 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import Webcam from "react-webcam";
-import { Modal } from "../ui/Modal";
-import { Button } from "../ui/Button";
+import { BarcodeConfirmModal } from "./BarcodeConfirmModal";
 import styles from "./BarcodeScanner.module.css";
 // Import the barcode-detector polyfill
 import "barcode-detector";
 
 interface BarcodeScannerProps {
-  onBarcodeScanned?: (value: string) => void;
+  onBarcodeScanned?: (value: string, quantity: number) => void;
 }
 
 export function BarcodeScanner({ onBarcodeScanned }: BarcodeScannerProps) {
@@ -23,9 +22,9 @@ export function BarcodeScanner({ onBarcodeScanned }: BarcodeScannerProps) {
   const [pendingBarcode, setPendingBarcode] = useState<string | null>(null);
   const [scanning, setScanning] = useState(true);
 
-  const confirmBarcode = () => {
+  const confirmBarcode = (qty: number) => {
     if (!pendingBarcode) return;
-    onBarcodeScanned?.(pendingBarcode);
+    onBarcodeScanned?.(pendingBarcode, qty);
     setLastBarcode(pendingBarcode);
     lastRef.current = pendingBarcode;
     setPendingBarcode(null);
@@ -173,50 +172,19 @@ export function BarcodeScanner({ onBarcodeScanned }: BarcodeScannerProps) {
       {lastBarcode && (
         <div className={styles.last}>Last scanned: {lastBarcode}</div>
       )}
-      <Modal
+      <BarcodeConfirmModal
+        barcode={pendingBarcode ?? ""}
         isOpen={!!pendingBarcode}
         onClose={() => {
           setPendingBarcode(null);
           setScanning(true);
         }}
-      >
-        {pendingBarcode && (
-          <div
-            onKeyDown={(e) => {
-              if (e.key === "Enter") confirmBarcode();
-            }}
-          >
-            <div style={{ textAlign: "center", marginBottom: "1rem" }}>
-              <span style={{ fontSize: "2rem", color: "green" }}>✔</span>
-            </div>
-            <p style={{ marginBottom: "1rem", textAlign: "center" }}>
-              Detected barcode:
-              <br />
-              <strong>{pendingBarcode}</strong>
-            </p>
-            <div
-              style={{
-                display: "flex",
-                gap: "0.5rem",
-                justifyContent: "center",
-              }}
-            >
-              <Button onClick={confirmBarcode} autoFocus>
-                Confirm
-              </Button>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  setPendingBarcode(null);
-                  setScanning(true);
-                }}
-              >
-                Try Again
-              </Button>
-            </div>
-          </div>
-        )}
-      </Modal>
+        onConfirm={(qty) => confirmBarcode(qty)}
+        onTryAgain={() => {
+          setPendingBarcode(null);
+          setScanning(true);
+        }}
+      />
     </div>
   );
 }

--- a/codex-build-app/src/app/components/check-in/ManualBarcodeEntry.tsx
+++ b/codex-build-app/src/app/components/check-in/ManualBarcodeEntry.tsx
@@ -3,30 +3,46 @@
 import { useState, FormEvent } from 'react';
 import { Input } from '../ui/Input';
 import { Button } from '../ui/Button';
+import { BarcodeConfirmModal } from './BarcodeConfirmModal';
 import styles from './ManualBarcodeEntry.module.css';
 
 interface ManualBarcodeEntryProps {
-  onSubmit?: (barcode: string) => void;
+  onSubmit?: (barcode: string, quantity: number) => void;
 }
 
 export function ManualBarcodeEntry({ onSubmit }: ManualBarcodeEntryProps) {
   const [barcode, setBarcode] = useState('');
+  const [pendingBarcode, setPendingBarcode] = useState<string | null>(null);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     if (!barcode) return;
-    onSubmit?.(barcode);
+    setPendingBarcode(barcode);
+  };
+
+  const handleConfirm = (qty: number) => {
+    if (!pendingBarcode) return;
+    onSubmit?.(pendingBarcode, qty);
     setBarcode('');
+    setPendingBarcode(null);
   };
 
   return (
-    <form onSubmit={handleSubmit} className={styles.form}>
-      <Input
-        value={barcode}
-        onChange={(e) => setBarcode(e.target.value)}
-        placeholder="Enter barcode"
+    <>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <Input
+          value={barcode}
+          onChange={(e) => setBarcode(e.target.value)}
+          placeholder="Enter barcode"
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+      <BarcodeConfirmModal
+        barcode={pendingBarcode ?? ''}
+        isOpen={!!pendingBarcode}
+        onConfirm={handleConfirm}
+        onClose={() => setPendingBarcode(null)}
       />
-      <Button type="submit">Submit</Button>
-    </form>
+    </>
   );
 }

--- a/codex-build-app/src/app/components/history/HistoryItemCard.tsx
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.tsx
@@ -16,12 +16,13 @@ export function HistoryItemCard({
   onCheckIn,
   onDelete,
 }: HistoryItemCardProps) {
-  const { barcode, quantity, scannedAt, location } = item;
+  const { barcode, name, quantity, scannedAt, location } = item;
   const locationName =
     typeof location === "object" && location ? location.name : undefined;
 
   return (
     <div className={styles.card}>
+      <h3 className={styles.name}>{name}</h3>
       <div className={styles.meta}>
         <span className={styles.label}>Barcode:</span> {barcode}
       </div>


### PR DESCRIPTION
## Summary
- create `BarcodeConfirmModal` with quantity adjustment controls
- show the confirmation modal from `BarcodeScanner` when a barcode is detected
- use the same modal for manual barcode entry
- pass quantity to the check‑in page logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*