### PR TITLE
Refactor styles for check-in page and add BarcodeConfirmModal component

### DIFF
--- a/codex-build-app/src/app/(pages)/check-in/page.module.css
+++ b/codex-build-app/src/app/(pages)/check-in/page.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 1.5rem;
   padding: 1.5rem;
-  max-width: 1024px;
+  max-width: 612px;
   margin: 0 auto;
 }
 
@@ -11,13 +11,6 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-@media (min-width: 768px) {
-  .content {
-    flex-direction: row;
-    align-items: flex-start;
-  }
 }
 
 .scanner {

--- a/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
+++ b/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css
@@ -1,0 +1,78 @@
+.modal {
+  max-width: 90vw;
+  padding: 2.5rem;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  text-align: center;
+}
+
+.barcodeInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon {
+  font-size: 2rem;
+  color: green;
+}
+
+.quantityRow {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.qtyInput {
+  width: 3rem;
+  max-width: 4rem;
+  text-align: center;
+  font-size: 1rem;
+  padding: 0.25rem;
+  background: var(--surface);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: inherit;
+}
+
+.qtyButton {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  background: var(--surface);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.qtyButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .qtyInput {
+    background: #1e1e1e;
+    border-color: #555;
+  }
+
+  .qtyButton {
+    background: #1e1e1e;
+    border-color: #555;
+  }
+}

--- a/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.tsx
+++ b/codex-build-app/src/app/components/check-in/BarcodeConfirmModal.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal } from "../ui/Modal";
+import { Button } from "../ui/Button";
+import styles from "./BarcodeConfirmModal.module.css";
+
+interface BarcodeConfirmModalProps {
+  barcode: string;
+  isOpen: boolean;
+  onConfirm: (quantity: number) => void;
+  onTryAgain?: () => void;
+  onClose?: () => void;
+}
+
+export function BarcodeConfirmModal({
+  barcode,
+  isOpen,
+  onConfirm,
+  onTryAgain,
+  onClose,
+}: BarcodeConfirmModalProps) {
+  const [quantity, setQuantity] = useState(1);
+
+  useEffect(() => {
+    if (isOpen) setQuantity(1);
+  }, [isOpen]);
+
+  const decrease = () => setQuantity((q) => Math.max(1, q - 1));
+  const increase = () => setQuantity((q) => q + 1);
+
+  const handleConfirm = () => {
+    onConfirm(quantity);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className={styles.modal}>
+      <div
+        className={styles.content}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleConfirm();
+          }
+        }}
+      >
+        <div className={styles.barcodeInfo}>
+          <span className={styles.icon}>✔</span>
+          <p className={styles.message}>
+            Detected barcode:
+            <br />
+            <strong>{barcode}</strong>
+          </p>
+        </div>
+        <div className={styles.quantityRow}>
+          <button
+            type="button"
+            onClick={decrease}
+            disabled={quantity <= 1}
+            aria-label="Decrease quantity"
+            className={styles.qtyButton}
+          >
+            -
+          </button>
+          <input
+            type="number"
+            min={1}
+            value={quantity}
+            onChange={(e) => setQuantity(Math.max(1, Number(e.target.value)))}
+            className={styles.qtyInput}
+          />
+          <button
+            type="button"
+            onClick={increase}
+            aria-label="Increase quantity"
+            className={styles.qtyButton}
+          >
+            +
+          </button>
+        </div>
+        <div className={styles.actions}>
+          {onTryAgain && (
+            <Button variant="secondary" onClick={onTryAgain}>
+              Try Again
+            </Button>
+          )}
+          <Button onClick={handleConfirm} autoFocus>
+            Confirm
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/codex-build-app/src/app/components/history/CheckInItemModal.tsx
+++ b/codex-build-app/src/app/components/history/CheckInItemModal.tsx
@@ -44,7 +44,7 @@ export function CheckInItemModal({
     <>
       <Modal isOpen={isOpen} onClose={onClose} className={styles.modal}>
         <div className={styles.header}>
-          <h2 className={styles.title}>Choose Storage</h2>
+          <h2 className={styles.title}>Choose a Storage</h2>
           <button
             type="button"
             aria-label="Close"

--- a/codex-build-app/src/app/components/history/HistoryItemCard.module.css
+++ b/codex-build-app/src/app/components/history/HistoryItemCard.module.css
@@ -14,6 +14,10 @@
   cursor: pointer;
 }
 
+.card:hover {
+  background-color: #0e1726;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .card:hover {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);

--- a/codex-build-app/src/app/components/storage/LocationCard.module.css
+++ b/codex-build-app/src/app/components/storage/LocationCard.module.css
@@ -11,6 +11,10 @@
   transition: box-shadow 0.2s;
 }
 
+.card:hover {
+  background-color: #0e1726;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .card:hover {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
This pull request introduces several updates to the `codex-build-app` project, including UI enhancements, new modal functionality, and minor text adjustments. The most significant changes involve adding a new `BarcodeConfirmModal` component, refining styles for hover effects, and improving the layout of the check-in page. Below is a categorized summary of the most important changes:

### New Modal Component:
* Added a `BarcodeConfirmModal` component to handle barcode confirmation, including quantity selection and user actions. The component uses React state and effects to manage quantity and modal behavior. (`codex-build-app/src/app/components/check-in/BarcodeConfirmModal.tsx`, `codex-build-app/src/app/components/check-in/BarcodeConfirmModal.module.css`) [[1]](diffhunk://#diff-ad239a5a6f0421e83838a434b6ef7f12505fb0e154f4e6d16c9efd8e91aa8f88R1-R94) [[2]](diffhunk://#diff-ffe04896c12ce891f069b0f22d316f1dff6676e3c3fe56e1aaeab8fe11094e11R1-R78)

### Style Enhancements:
* Updated hover effects for `.card` elements in `HistoryItemCard` and `LocationCard` components, adding a background color change for a more interactive user experience. (`codex-build-app/src/app/components/history/HistoryItemCard.module.css`, `codex-build-app/src/app/components/storage/LocationCard.module.css`) [[1]](diffhunk://#diff-5f583bdd2946fae74316390bfc609e75910d2ccc0f95e5336c9c797dd9c0f04cR17-R20) [[2]](diffhunk://#diff-70520495558a21961ab65e10731b77f2175907d59c12f74a242743fc166880b4R14-R17)

### Layout Adjustments:
* Reduced the `max-width` of the check-in page container from `1024px` to `612px` for better responsiveness on smaller screens. (`codex-build-app/src/app/(pages)/check-in/page.module.css`)
* Removed the media query that adjusted the layout of the `.content` class for larger screens, simplifying the layout logic. (`codex-build-app/src/app/(pages)/check-in/page.module.css`)

### Text Updates:
* Changed the modal title in `CheckInItemModal` from "Choose Storage" to "Choose a Storage" for improved readability. (`codex-build-app/src/app/components/history/CheckInItemModal.tsx`)