### PR TITLE
Add sales orders page with login

### DIFF
--- a/codex-build-app/package-lock.json
+++ b/codex-build-app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@undecaf/barcode-detector-polyfill": "^0.9.21",
         "barcode-detector": "^3.0.4",
+        "dotenv": "^16.5.0",
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1978,6 +1979,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/codex-build-app/package.json
+++ b/codex-build-app/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@undecaf/barcode-detector-polyfill": "^0.9.21",
     "barcode-detector": "^3.0.4",
+    "dotenv": "^16.5.0",
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/codex-build-app/src/app/(pages)/login/page.module.css
+++ b/codex-build-app/src/app/(pages)/login/page.module.css
@@ -1,0 +1,18 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  max-width: 320px;
+  margin: 0 auto;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.error {
+  color: var(--danger);
+}

--- a/codex-build-app/src/app/(pages)/login/page.tsx
+++ b/codex-build-app/src/app/(pages)/login/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '../../components/ui/Input';
+import { Button } from '../../components/ui/Button';
+import { login } from '../../lib/authService';
+import { useSession } from '../../store/sessionStore';
+import styles from './page.module.css';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { setSession } = useSession();
+  const [loginId, setLoginId] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { sessionId } = await login(loginId, password);
+      setSession({ sessionId });
+      router.push('/sales-orders');
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <h1>Login</h1>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <Input
+          placeholder="Login ID"
+          value={loginId}
+          onChange={(e) => setLoginId(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className={styles.error}>{error}</p>}
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Logging in...' : 'Login'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/codex-build-app/src/app/(pages)/sales-orders/page.module.css
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.module.css
@@ -1,0 +1,56 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dates {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.statusTabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tab {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.activeTab {
+  background: var(--foreground);
+  color: var(--background);
+  border-color: var(--foreground);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #dddddd;
+  text-align: left;
+}
+
+@media (min-width: 640px) {
+  .filters {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+}

--- a/codex-build-app/src/app/(pages)/sales-orders/page.tsx
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '../../components/ui/Input';
+import { Button } from '../../components/ui/Button';
+import { useSession } from '../../store/sessionStore';
+import type { SalesOrder } from '../../types';
+import styles from './page.module.css';
+
+const mockOrders: SalesOrder[] = [
+  {
+    orderNumber: 'AB23G23G8C',
+    date: '2025-05-19',
+    status: '出荷準備中',
+    customer: 'エコエナジー研究所',
+    total: '1,089円',
+  },
+  {
+    orderNumber: 'CD34H56I7J',
+    date: '2025-05-20',
+    status: '出荷済み',
+    customer: 'スマートホーム株式会社',
+    total: '2,500円',
+  },
+  {
+    orderNumber: 'EF45I78K9L',
+    date: '2025-05-18',
+    status: 'キャンセル',
+    customer: 'グリーンエネルギー社',
+    total: '980円',
+  },
+  {
+    orderNumber: 'GH56J89L0M',
+    date: '2025-05-17',
+    status: '出荷準備中',
+    customer: '太陽光ソリューション',
+    total: '4,200円',
+  },
+  {
+    orderNumber: 'IJ67K90M1N',
+    date: '2025-05-19',
+    status: '出荷済み',
+    customer: 'クリーンパワーサービス',
+    total: '3,300円',
+  },
+];
+
+const statuses = ['全て', '出荷準備中', '出荷済み', 'キャンセル'];
+
+export default function SalesOrdersPage() {
+  const router = useRouter();
+  const { session } = useSession();
+  const [orders] = useState<SalesOrder[]>(mockOrders);
+  const [filtered, setFiltered] = useState<SalesOrder[]>(mockOrders);
+  const [status, setStatus] = useState('全て');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+
+  useEffect(() => {
+    if (!session?.sessionId) {
+      router.replace('/login');
+    }
+  }, [session, router]);
+
+  const handleSearch = () => {
+    let result = orders;
+    if (status !== '全て') {
+      result = result.filter((o) => o.status === status);
+    }
+    if (dateFrom) {
+      result = result.filter((o) => o.date >= dateFrom);
+    }
+    if (dateTo) {
+      result = result.filter((o) => o.date <= dateTo);
+    }
+    setFiltered(result);
+  };
+
+  useEffect(() => {
+    handleSearch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
+  if (!session?.sessionId) {
+    return null;
+  }
+
+  return (
+    <div className={styles.page}>
+      <h1>Sales Orders</h1>
+      <div className={styles.filters}>
+        <div className={styles.dates}>
+          <Input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)} />
+          <Input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)} />
+        </div>
+        <div className={styles.statusTabs}>
+          {statuses.map((s) => (
+            <button
+              key={s}
+              className={`${styles.tab} ${status === s ? styles.activeTab : ''}`}
+              onClick={() => setStatus(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        <Button type="button" onClick={handleSearch}>
+          Search
+        </Button>
+      </div>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>ORDER #</th>
+            <th>DATE</th>
+            <th>STATUS</th>
+            <th>CUSTOMER</th>
+            <th>TOTAL</th>
+            <th>ACTIONS</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((order) => (
+            <tr key={order.orderNumber}>
+              <td>{order.orderNumber}</td>
+              <td>{order.date}</td>
+              <td>{order.status}</td>
+              <td>{order.customer}</td>
+              <td>{order.total}</td>
+              <td>
+                <Button type="button" variant="secondary">
+                  View
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/codex-build-app/src/app/lib/authService.ts
+++ b/codex-build-app/src/app/lib/authService.ts
@@ -1,13 +1,14 @@
-const API_BASE_URL = 'http://localhost:5002';
-const HISTORY_APP_ID = 'history-app';
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5001";
+const HISTORY_APP_ID = process.env.NEXT_PUBLIC_HISTORY_APP_ID || "";
 
 export async function login(loginId: string, password: string) {
   const response = await fetch(
     `${API_BASE_URL}/auth/login?applicationId=${HISTORY_APP_ID}`,
     {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({ loginId, password }),
     }
@@ -15,7 +16,7 @@ export async function login(loginId: string, password: string) {
 
   if (!response.ok) {
     const message = await response.text();
-    throw new Error(message || 'Login failed');
+    throw new Error(message || "Login failed");
   }
 
   return response.json() as Promise<{ sessionId: string }>;

--- a/codex-build-app/src/app/lib/authService.ts
+++ b/codex-build-app/src/app/lib/authService.ts
@@ -1,0 +1,22 @@
+const API_BASE_URL = 'http://localhost:5002';
+const HISTORY_APP_ID = 'history-app';
+
+export async function login(loginId: string, password: string) {
+  const response = await fetch(
+    `${API_BASE_URL}/auth/login?applicationId=${HISTORY_APP_ID}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ loginId, password }),
+    }
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'Login failed');
+  }
+
+  return response.json() as Promise<{ sessionId: string }>;
+}

--- a/codex-build-app/src/app/page.tsx
+++ b/codex-build-app/src/app/page.tsx
@@ -26,6 +26,9 @@ export default function Home() {
             Manage Storage
           </Button>
         </Link>
+        <Link href="/sales-orders">
+          <Button type="button" variant="secondary">Sales Orders</Button>
+        </Link>
       </div>
     </div>
   );

--- a/codex-build-app/src/app/store/StoreProvider.tsx
+++ b/codex-build-app/src/app/store/StoreProvider.tsx
@@ -3,11 +3,14 @@
 import { ReactNode } from "react";
 import { ItemStoreProvider } from "./itemStore";
 import { LocationStoreProvider } from "./locationStore";
+import { SessionProvider } from "./sessionStore";
 
 export function StoreProvider({ children }: { children: ReactNode }) {
   return (
-    <ItemStoreProvider>
-      <LocationStoreProvider>{children}</LocationStoreProvider>
-    </ItemStoreProvider>
+    <SessionProvider>
+      <ItemStoreProvider>
+        <LocationStoreProvider>{children}</LocationStoreProvider>
+      </ItemStoreProvider>
+    </SessionProvider>
   );
 }

--- a/codex-build-app/src/app/store/sessionStore.tsx
+++ b/codex-build-app/src/app/store/sessionStore.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+export interface Session {
+  sessionId: string;
+}
+
+export interface SessionStore {
+  session: Session | null;
+  setSession: (session: Session | null) => void;
+}
+
+const SessionContext = createContext<SessionStore | undefined>(undefined);
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const [session, setSessionState] = useState<Session | null>(null);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('session') : null;
+    if (stored) {
+      try {
+        setSessionState(JSON.parse(stored));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  const setSession = (sess: Session | null) => {
+    setSessionState(sess);
+    if (typeof window === 'undefined') return;
+    if (sess) {
+      localStorage.setItem('session', JSON.stringify(sess));
+    } else {
+      localStorage.removeItem('session');
+    }
+  };
+
+  const value: SessionStore = { session, setSession };
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}
+
+export function useSession(): SessionStore {
+  const context = useContext(SessionContext);
+  if (!context) {
+    throw new Error('useSession must be used within SessionProvider');
+  }
+  return context;
+}

--- a/codex-build-app/src/app/types/index.ts
+++ b/codex-build-app/src/app/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./item";
 export * from "./location";
+export * from "./order";

--- a/codex-build-app/src/app/types/order.ts
+++ b/codex-build-app/src/app/types/order.ts
@@ -1,0 +1,7 @@
+export interface SalesOrder {
+  orderNumber: string;
+  date: string;
+  status: string;
+  customer: string;
+  total: string;
+}


### PR DESCRIPTION
## Summary
- add a session store and provider
- add auth service for login
- implement login page
- create sales orders screen with filtering
- link Sales Orders from home page

## Testing
- `npm run lint` *(fails: next not found)*