### PR TITLE
Use real sales orders from API

### DIFF
--- a/codex-build-app/src/app/(pages)/login/page.tsx
+++ b/codex-build-app/src/app/(pages)/login/page.tsx
@@ -1,18 +1,18 @@
-'use client';
+"use client";
 
-import { FormEvent, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Input } from '../../components/ui/Input';
-import { Button } from '../../components/ui/Button';
-import { login } from '../../lib/authService';
-import { useSession } from '../../store/sessionStore';
-import styles from './page.module.css';
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "../../components/ui/Input";
+import { Button } from "../../components/ui/Button";
+import { login } from "../../lib/authService";
+import { useSession } from "../../store/sessionStore";
+import styles from "./page.module.css";
 
 export default function LoginPage() {
   const router = useRouter();
   const { setSession } = useSession();
-  const [loginId, setLoginId] = useState('');
-  const [password, setPassword] = useState('');
+  const [loginId, setLoginId] = useState("");
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,11 +22,18 @@ export default function LoginPage() {
     setLoading(true);
     try {
       const { sessionId } = await login(loginId, password);
-      setSession({ sessionId });
-      router.push('/sales-orders');
+
+      // Set the session with the sessionId and 24 hour expiration
+      const expiresAt = Date.now() + 24 * 60 * 60 * 1000; // 24 hours from now
+      setSession({ sessionId, expiresAt });
+
+      // Small delay to ensure localStorage is updated before navigation
+      setTimeout(() => {
+        router.push("/sales-orders");
+      }, 100);
     } catch (err) {
       console.error(err);
-      setError(err instanceof Error ? err.message : 'Login failed');
+      setError(err instanceof Error ? err.message : "Login failed");
     } finally {
       setLoading(false);
     }
@@ -49,7 +56,7 @@ export default function LoginPage() {
         />
         {error && <p className={styles.error}>{error}</p>}
         <Button type="submit" disabled={loading}>
-          {loading ? 'Logging in...' : 'Login'}
+          {loading ? "Logging in..." : "Login"}
         </Button>
       </form>
     </div>

--- a/codex-build-app/src/app/(pages)/sales-orders/page.module.css
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.module.css
@@ -1,19 +1,51 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   padding: 1.5rem;
+  max-width: 1224px;
+  margin: 0 auto;
+  overflow-x: auto;
+}
+
+.pageTitle {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #fff;
+  border-bottom: 2px solid #eaeaea;
+  padding-bottom: 0.75rem;
 }
 
 .filters {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  background-color: rgba(0, 0, 0, 0.03);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .dates {
   display: flex;
-  gap: 0.5rem;
+  gap: 1rem;
+}
+
+.dateInputWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dateLabel {
+  font-size: 0.8rem;
+  color: #fff;
+  font-weight: 500;
+}
+
+.dateInput {
+  min-width: 160px;
+  border-color: #ddd;
 }
 
 .statusTabs {
@@ -23,38 +55,135 @@
 }
 
 .tab {
-  padding: 0.25rem 0.75rem;
+  padding: 0.375rem 0.875rem;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: 6px;
   background: transparent;
   cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 0.9rem;
+}
+
+.tab:hover {
+  background: rgba(224, 223, 223, 0.9);
 }
 
 .activeTab {
   background: var(--foreground);
   color: var(--background);
   border-color: var(--foreground);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
-.table th,
-.table td {
-  padding: 0.5rem;
-  border-bottom: 1px solid #dddddd;
+.table th {
+  padding: 0.75rem 1rem;
+  background-color: #f5f5f7;
+  border-bottom: 1px solid #e5e5e5;
   text-align: left;
+  font-weight: 600;
+  color: #333;
+}
+
+.table td {
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid #eeeeee;
+  text-align: left;
+  background-color: #171717;
+}
+
+.table tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.015);
+}
+
+.price {
+  text-align: right;
+  font-family: monospace;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.actionCell {
+  text-align: center;
+  width: 100px;
+}
+
+.viewButton {
+  min-width: 80px;
+  font-size: 0.875rem;
+  transition: all 0.2s ease;
+  padding: 0.35rem 0.75rem;
+}
+
+.statusBadge {
+  display: inline-block;
+  padding: 0.25rem 0.625rem;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+  background-color: #e9ecef;
+  color: #495057;
+}
+
+/* Status colors */
+.status01,
+.status05,
+.status06,
+.status08,
+.status09 {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.status02,
+.status03,
+.status04,
+.status07 {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.status11,
+.status12 {
+  background-color: #cce5ff;
+  color: #004085;
+}
+
+.status16,
+.status17,
+.status99 {
+  background-color: #f8d7da;
+  color: #721c24;
 }
 
 .error {
   color: var(--danger);
+  padding: 0.5rem;
+  background-color: rgba(255, 0, 0, 0.05);
+  border-radius: 6px;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 768px) {
   .filters {
     flex-direction: row;
     align-items: flex-end;
+    gap: 1.5rem;
+  }
+
+  .dates {
+    flex: 0 0 auto;
+  }
+
+  .statusTabs {
+    flex: 1;
   }
 }

--- a/codex-build-app/src/app/(pages)/sales-orders/page.module.css
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.module.css
@@ -48,6 +48,10 @@
   text-align: left;
 }
 
+.error {
+  color: var(--danger);
+}
+
 @media (min-width: 640px) {
   .filters {
     flex-direction: row;

--- a/codex-build-app/src/app/(pages)/sales-orders/page.tsx
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.tsx
@@ -1,29 +1,74 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Input } from '../../components/ui/Input';
-import { Button } from '../../components/ui/Button';
-import { useSession } from '../../store/sessionStore';
-import { salesOrderApiRequest } from '../../lib/salesOrderApi';
-import type { SalesOrder } from '../../types';
-import styles from './page.module.css';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input } from "../../components/ui/Input";
+import { Button } from "../../components/ui/Button";
+import { useSession } from "../../store/sessionStore";
+import { salesOrderApiRequest } from "../../lib/salesOrderApi";
+import type { SalesOrder } from "../../types";
+import styles from "./page.module.css";
 
-const statuses = ['全て', '出荷準備中', '出荷済み', 'キャンセル'];
+const statuses = ["全て", "出荷準備中", "出荷済み", "キャンセル"];
 
 export default function SalesOrdersPage() {
+  // Helper function to get date in YYYY-MM-DD format
+  const formatDateToYYYYMMDD = (date) => {
+    return date.toISOString().split("T")[0]; // Returns YYYY-MM-DD
+  };
+
+  // Calculate default dates (3 months ago to today)
+  const getDefaultDates = () => {
+    const today = new Date();
+    const threeMonthsAgo = new Date();
+    threeMonthsAgo.setMonth(today.getMonth() - 3);
+
+    return {
+      from: formatDateToYYYYMMDD(threeMonthsAgo),
+      to: formatDateToYYYYMMDD(today),
+    };
+  };
+
+  const defaultDates = getDefaultDates();
+
+  // Helper function to convert UI status to API status codes
+  const mapStatusToCode = (status: string): string => {
+    switch (status) {
+      case "入金待ち":
+        return "11,12";
+      case "出荷準備中":
+        return "02,03";
+      case "出荷済み":
+        return "01,04,05,07,08";
+      case "着荷済み":
+        return "06,09";
+      case "キャンセル済み":
+        return "99,16,17";
+      default:
+        return "01,02,03,04,05,06,07,08,09,11,12,16,17,99";
+    }
+  };
+
   const router = useRouter();
   const { session } = useSession();
   const [orders, setOrders] = useState<SalesOrder[]>([]);
-  const [status, setStatus] = useState('全て');
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
+  const [status, setStatus] = useState("全て");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useState({
+    salesOrderDateFrom: defaultDates.from,
+    salesOrderDateTo: defaultDates.to,
+    soSlipStatus: "01,02,03,04,05,06,07,08,09,11,12,16,17,99", // All statuses by default
+    sortby: "-registerDateTimeHeader,soLineNumber",
+    limit: "500", // Changed to string to match API expectations
+    offset: "1", // Changed to string to match API expectations
+  });
 
   useEffect(() => {
     if (!session?.sessionId) {
-      router.replace('/login');
+      router.replace("/login");
     } else {
       handleSearch();
     }
@@ -35,15 +80,27 @@ export default function SalesOrdersPage() {
     setLoading(true);
     setError(null);
     try {
-      const params: Record<string, string> = {};
-      if (dateFrom) params.dateFrom = dateFrom;
-      if (dateTo) params.dateTo = dateTo;
-      if (status !== '全て') params.status = status;
-      const data = await salesOrderApiRequest('sales-orders', params);
-      setOrders(data as SalesOrder[]);
+      // Create updated params with current filter values
+      const updatedParams = {
+        ...searchParams,
+        salesOrderDateFrom: dateFrom || defaultDates.from,
+        salesOrderDateTo: dateTo || defaultDates.to,
+        // Update status codes based on selection if needed
+        soSlipStatus:
+          status !== "全て"
+            ? mapStatusToCode(status)
+            : "01,02,03,04,05,06,07,08,09,11,12,16,17,99",
+      };
+
+      // Update the state
+      setSearchParams(updatedParams);
+
+      // Send the updated params to the API (use the updatedParams object directly)
+      const data = await salesOrderApiRequest(updatedParams);
+      setOrders(data.soSlipList as SalesOrder[]);
     } catch (err) {
       console.error(err);
-      setError(err instanceof Error ? err.message : 'Fetch failed');
+      setError(err instanceof Error ? err.message : "Fetch failed");
     } finally {
       setLoading(false);
     }
@@ -58,14 +115,24 @@ export default function SalesOrdersPage() {
       <h1>Sales Orders</h1>
       <div className={styles.filters}>
         <div className={styles.dates}>
-          <Input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)} />
-          <Input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)} />
+          <Input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+          />
+          <Input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+          />
         </div>
         <div className={styles.statusTabs}>
           {statuses.map((s) => (
             <button
               key={s}
-              className={`${styles.tab} ${status === s ? styles.activeTab : ''}`}
+              className={`${styles.tab} ${
+                status === s ? styles.activeTab : ""
+              }`}
               onClick={() => setStatus(s)}
             >
               {s}
@@ -73,7 +140,7 @@ export default function SalesOrdersPage() {
           ))}
         </div>
         <Button type="button" onClick={handleSearch} disabled={loading}>
-          {loading ? 'Loading...' : 'Search'}
+          {loading ? "Loading..." : "Search"}
         </Button>
       </div>
       {error && <p className={styles.error}>{error}</p>}
@@ -90,12 +157,12 @@ export default function SalesOrdersPage() {
         </thead>
         <tbody>
           {orders.map((order) => (
-            <tr key={order.orderNumber}>
-              <td>{order.orderNumber}</td>
-              <td>{order.date}</td>
-              <td>{order.status}</td>
-              <td>{order.customer}</td>
-              <td>{order.total}</td>
+            <tr key={order.soSlipNumber}>
+              <td>{order.soSlipNumber}</td>
+              <td>{order.salesOrderDateTime}</td>
+              <td>{order.soSlipStatus}</td>
+              <td>{order.customer?.customerName}</td>
+              <td>{order.amount?.totalSalesAmountIncludingTax}</td>
               <td>
                 <Button type="button" variant="secondary">
                   View

--- a/codex-build-app/src/app/(pages)/sales-orders/page.tsx
+++ b/codex-build-app/src/app/(pages)/sales-orders/page.tsx
@@ -9,11 +9,22 @@ import { salesOrderApiRequest } from "../../lib/salesOrderApi";
 import type { SalesOrder } from "../../types";
 import styles from "./page.module.css";
 
-const statuses = ["全て", "出荷準備中", "出荷済み", "キャンセル"];
+// Helper function to get date in YYYY-MM-DD format
+interface FormatDateToYYYYMMDD {
+  (date: Date): string;
+}
+
+const statuses = [
+  "全て",
+  "入金待ち",
+  "出荷準備中",
+  "出荷済み",
+  "着荷済み",
+  "キャンセル済み",
+];
 
 export default function SalesOrdersPage() {
-  // Helper function to get date in YYYY-MM-DD format
-  const formatDateToYYYYMMDD = (date) => {
+  const formatDateToYYYYMMDD: FormatDateToYYYYMMDD = (date) => {
     return date.toISOString().split("T")[0]; // Returns YYYY-MM-DD
   };
 
@@ -53,8 +64,8 @@ export default function SalesOrdersPage() {
   const { session } = useSession();
   const [orders, setOrders] = useState<SalesOrder[]>([]);
   const [status, setStatus] = useState("全て");
-  const [dateFrom, setDateFrom] = useState("");
-  const [dateTo, setDateTo] = useState("");
+  const [dateFrom, setDateFrom] = useState(defaultDates.from);
+  const [dateTo, setDateTo] = useState(defaultDates.to);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useState({
@@ -106,25 +117,84 @@ export default function SalesOrdersPage() {
     }
   };
 
+  // Helper functions for formatting
+  const formatDateTime = (dateString: string | undefined): string => {
+    if (!dateString) return "-";
+    const date = new Date(dateString);
+    return date
+      .toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      })
+      .replace(/\//g, "/");
+  };
+
+  const formatPrice = (price: string | number | undefined): string => {
+    if (price === undefined || price === null) return "-";
+    try {
+      // Handle both string and number types
+      const numValue = typeof price === "number" ? price : parseFloat(price);
+      if (isNaN(numValue)) return "-";
+      return numValue.toLocaleString("ja-JP");
+    } catch (error) {
+      console.error("Error formatting price:", error);
+      return "-";
+    }
+  };
+
+  const getStatusName = (statusCode: string | undefined): string => {
+    if (!statusCode) return "Unknown";
+
+    const statusMap: Record<string, string> = {
+      "01": "処理済",
+      "02": "準備中",
+      "03": "準備完了",
+      "04": "出荷中",
+      "05": "出荷済",
+      "06": "着荷済",
+      "07": "部分出荷中",
+      "08": "部分出荷済",
+      "09": "部分着荷済",
+      "11": "入金待ち",
+      "12": "一部入金済",
+      "16": "キャンセル依頼",
+      "17": "部分キャンセル",
+      "99": "キャンセル済",
+    };
+
+    // Ensure statusCode is a string that exists in the map
+    const code = String(statusCode).padStart(2, "0");
+    return statusMap[code] || `Status ${statusCode}`;
+  };
+
   if (!session?.sessionId) {
     return null;
   }
 
   return (
     <div className={styles.page}>
-      <h1>Sales Orders</h1>
+      <h1 className={styles.pageTitle}>Sales Orders</h1>
       <div className={styles.filters}>
         <div className={styles.dates}>
-          <Input
-            type="date"
-            value={dateFrom}
-            onChange={(e) => setDateFrom(e.target.value)}
-          />
-          <Input
-            type="date"
-            value={dateTo}
-            onChange={(e) => setDateTo(e.target.value)}
-          />
+          <div className={styles.dateInputWrapper}>
+            <label className={styles.dateLabel}>From:</label>
+            <Input
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className={styles.dateInput}
+            />
+          </div>
+          <div className={styles.dateInputWrapper}>
+            <label className={styles.dateLabel}>To:</label>
+            <Input
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className={styles.dateInput}
+            />
+          </div>
         </div>
         <div className={styles.statusTabs}>
           {statuses.map((s) => (
@@ -144,34 +214,68 @@ export default function SalesOrdersPage() {
         </Button>
       </div>
       {error && <p className={styles.error}>{error}</p>}
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>ORDER #</th>
-            <th>DATE</th>
-            <th>STATUS</th>
-            <th>CUSTOMER</th>
-            <th>TOTAL</th>
-            <th>ACTIONS</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map((order) => (
-            <tr key={order.soSlipNumber}>
-              <td>{order.soSlipNumber}</td>
-              <td>{order.salesOrderDateTime}</td>
-              <td>{order.soSlipStatus}</td>
-              <td>{order.customer?.customerName}</td>
-              <td>{order.amount?.totalSalesAmountIncludingTax}</td>
-              <td>
-                <Button type="button" variant="secondary">
-                  View
-                </Button>
-              </td>
+      <div style={{ position: "relative" }}>
+        {loading && (
+          <div className={styles.loadingOverlay}>
+            <div className={styles.spinner}></div>
+          </div>
+        )}
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ORDER #</th>
+              <th>DATE</th>
+              <th>STATUS</th>
+              <th>CUSTOMER</th>
+              <th>TOTAL</th>
+              <th>ACTIONS</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {orders.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  style={{ textAlign: "center", padding: "2rem" }}
+                >
+                  {loading
+                    ? "Loading orders..."
+                    : "No orders found matching your criteria"}
+                </td>
+              </tr>
+            ) : (
+              orders.map((order) => (
+                <tr key={order.soSlipNumber}>
+                  <td>{order.soSlipNumber}</td>
+                  <td>{formatDateTime(order.salesOrderDateTime)}</td>
+                  <td>
+                    <span
+                      className={`${styles.statusBadge} ${
+                        styles[`status${order.soSlipStatus}`] || ""
+                      }`}
+                    >
+                      {getStatusName(order.soSlipStatus)}
+                    </span>
+                  </td>
+                  <td>{order.customer?.customerName}</td>
+                  <td className={styles.price}>
+                    ￥{formatPrice(order.amount?.totalSalesAmountIncludingTax)}
+                  </td>
+                  <td className={styles.actionCell}>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className={styles.viewButton}
+                    >
+                      View
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/codex-build-app/src/app/lib/salesOrderApi.ts
+++ b/codex-build-app/src/app/lib/salesOrderApi.ts
@@ -1,8 +1,7 @@
 const SALES_ORDER_API_URL =
-  process.env.NEXT_PUBLIC_SALES_ORDER_API_URL || "http://localhost:5002";
+  process.env.NEXT_PUBLIC_SALES_ORDER_API_URL || "http://localhost:5001";
 
 export async function salesOrderApiRequest(
-  endpoint: string,
   params: Record<string, string> = {},
   options: RequestInit = {}
 ): Promise<any> {
@@ -15,7 +14,7 @@ export async function salesOrderApiRequest(
   }
 
   const query = new URLSearchParams(params).toString();
-  const url = `${SALES_ORDER_API_URL}/${endpoint}${query ? `?${query}` : ""}`;
+  const url = `${SALES_ORDER_API_URL}${query ? `?${query}` : ""}`;
 
   const headers = {
     Authorization: `Bearer ${sessionId}`,

--- a/codex-build-app/src/app/lib/salesOrderApi.ts
+++ b/codex-build-app/src/app/lib/salesOrderApi.ts
@@ -1,0 +1,54 @@
+const SALES_ORDER_API_URL =
+  process.env.NEXT_PUBLIC_SALES_ORDER_API_URL || "http://localhost:5002";
+
+export async function salesOrderApiRequest(
+  endpoint: string,
+  params: Record<string, string> = {},
+  options: RequestInit = {}
+): Promise<any> {
+  const stored =
+    typeof window !== "undefined" ? localStorage.getItem("session") : null;
+  const sessionId = stored ? JSON.parse(stored).sessionId : null;
+
+  if (!sessionId) {
+    throw new Error("No session found");
+  }
+
+  const query = new URLSearchParams(params).toString();
+  const url = `${SALES_ORDER_API_URL}/${endpoint}${query ? `?${query}` : ""}`;
+
+  const headers = {
+    Authorization: `Bearer ${sessionId}`,
+    "Content-Type": "application/json",
+    "X-Language-Code": "JPN",
+    "X-Client-Program": "JP_ORDER",
+    ...(options.headers || {}),
+  };
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    ...options,
+  });
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      if (typeof window !== "undefined") {
+        window.location.href = "/login";
+      }
+      throw new Error("Session expired");
+    }
+    let errorMessage = "Fetch failed";
+    try {
+      const error = await response.json();
+      errorMessage = error.message || errorMessage;
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(errorMessage);
+  }
+
+  return response.json();
+}
+
+export { SALES_ORDER_API_URL };

--- a/codex-build-app/src/app/lib/salesOrderApi.ts
+++ b/codex-build-app/src/app/lib/salesOrderApi.ts
@@ -4,7 +4,7 @@ const SALES_ORDER_API_URL =
 export async function salesOrderApiRequest(
   params: Record<string, string> = {},
   options: RequestInit = {}
-): Promise<any> {
+): Promise<{ soSlipList: unknown[] }> {
   const stored =
     typeof window !== "undefined" ? localStorage.getItem("session") : null;
   const sessionId = stored ? JSON.parse(stored).sessionId : null;

--- a/codex-build-app/src/app/store/sessionStore.tsx
+++ b/codex-build-app/src/app/store/sessionStore.tsx
@@ -83,9 +83,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   // This prevents hydration mismatch warnings
   return (
     <SessionContext.Provider value={value}>
-      {/* Use invisible loading state instead of conditional rendering to avoid hydration errors */}
-      {!isInitialized && typeof window !== "undefined" ? (
-        <div style={{ display: "none" }}>Loading session...</div>
+      {/* Phần này render giống hệt nhau trên server & client */}
+      {!isInitialized ? (
+        <div style={{ visibility: "hidden" }}>Loading session...</div>
       ) : (
         children
       )}

--- a/codex-build-app/src/app/types/order.ts
+++ b/codex-build-app/src/app/types/order.ts
@@ -1,7 +1,7 @@
 export interface SalesOrder {
-  orderNumber: string;
-  date: string;
-  status: string;
-  customer: string;
-  total: string;
+  soSlipNumber: string;
+  salesOrderDateTime: string;
+  soSlipStatus: string;
+  customer: never;
+  amount: never;
 }

--- a/codex-build-app/src/app/types/order.ts
+++ b/codex-build-app/src/app/types/order.ts
@@ -2,6 +2,19 @@ export interface SalesOrder {
   soSlipNumber: string;
   salesOrderDateTime: string;
   soSlipStatus: string;
-  customer: never;
-  amount: never;
+  customer?: {
+    customerName?: string;
+    customerId?: string;
+  };
+  amount?: {
+    totalSalesAmountIncludingTax?: string | number;
+    subTotal?: string | number;
+    totalTaxAmount?: string | number;
+  };
+  items?: Array<{
+    itemId: string;
+    itemName?: string;
+    quantity?: number;
+    price?: string | number;
+  }>;
 }


### PR DESCRIPTION
## Summary
- fetch real sales orders with new `salesOrderApiRequest` helper
- show loading and error states while fetching orders

## Testing
- `npm run lint` *(fails: `next` not found)*